### PR TITLE
Dismissing ROLE_NONE in RoleDefintion

### DIFF
--- a/src/main/kotlin/com/cosmotech/api/rbac/CsmRbac.kt
+++ b/src/main/kotlin/com/cosmotech/api/rbac/CsmRbac.kt
@@ -78,7 +78,9 @@ open class CsmRbac(
       rolesDefinition: RolesDefinition = getCommonRolesDefinition()
   ): RbacSecurity {
     logger.info("RBAC ${rbacSecurity.id} - Setting default security")
-    this.verifyRoleOrThrow(rbacSecurity, defaultRole, rolesDefinition)
+    if (defaultRole != ROLE_NONE) {
+      this.verifyRoleOrThrow(rbacSecurity, defaultRole, rolesDefinition)
+    }
     rbacSecurity.default = defaultRole
     return rbacSecurity
   }
@@ -171,8 +173,8 @@ open class CsmRbac(
       rolesDefinition: RolesDefinition
   ): Boolean {
     logger.debug("RBAC ${rbacSecurity.id} - Verifying default roles for permission: $permission")
-    val isAuthorized =
-        this.verifyPermissionFromRole(permission, rbacSecurity.default, rolesDefinition)
+    val defaultRole = if (rbacSecurity.default == ROLE_NONE) null else rbacSecurity.default
+    val isAuthorized = this.verifyPermissionFromRole(permission, defaultRole, rolesDefinition)
     logger.debug(
         "RBAC ${rbacSecurity.id} - default roles for permission $permission: $isAuthorized")
     return isAuthorized
@@ -190,7 +192,7 @@ open class CsmRbac(
 
   internal fun verifyPermissionFromRole(
       permission: String,
-      role: String,
+      role: String?,
       rolesDefinition: RolesDefinition
   ): Boolean {
     return this.verifyPermission(
@@ -198,14 +200,14 @@ open class CsmRbac(
   }
 
   internal fun getRolePermissions(
-      role: String,
+      role: String?,
       rolesDefinition: MutableMap<String, List<String>>
   ): List<String> {
     return rolesDefinition[role] ?: listOf()
   }
 
-  internal fun getUserRole(rbacSecurity: RbacSecurity, user: String): String {
-    return rbacSecurity.accessControlList.firstOrNull { it.id == user }?.role ?: ROLE_NONE
+  internal fun getUserRole(rbacSecurity: RbacSecurity, user: String): String? {
+    return rbacSecurity.accessControlList.firstOrNull { it.id == user }?.role
   }
 
   internal fun getAdminCount(rbacSecurity: RbacSecurity, rolesDefinition: RolesDefinition): Int {

--- a/src/main/kotlin/com/cosmotech/api/rbac/RolesDefinition.kt
+++ b/src/main/kotlin/com/cosmotech/api/rbac/RolesDefinition.kt
@@ -22,7 +22,6 @@ const val PERMISSION_DELETE = "delete"
 const val PERMISSION_LAUNCH = "launch"
 const val PERMISSION_VALIDATE = "validate"
 
-val COMMON_ROLE_NONE_PERMISSIONS: List<String> = listOf()
 val COMMON_ROLE_READER_PERMISSIONS = listOf(PERMISSION_READ, PERMISSION_READ_SECURITY)
 val COMMON_ROLE_USER_PERMISSIONS =
     listOf(PERMISSION_READ, PERMISSION_READ_SECURITY, PERMISSION_CREATE_CHILDREN)
@@ -93,7 +92,6 @@ fun getCommonRolesDefinition(): RolesDefinition {
   return RolesDefinition(
       permissions =
           mutableMapOf(
-              ROLE_NONE to COMMON_ROLE_NONE_PERMISSIONS,
               ROLE_VIEWER to COMMON_ROLE_READER_PERMISSIONS,
               ROLE_USER to COMMON_ROLE_USER_PERMISSIONS,
               ROLE_EDITOR to COMMON_ROLE_EDITOR_PERMISSIONS,
@@ -106,7 +104,6 @@ fun getScenarioRolesDefinition(): RolesDefinition {
   return RolesDefinition(
       permissions =
           mutableMapOf(
-              ROLE_NONE to COMMON_ROLE_NONE_PERMISSIONS,
               ROLE_VIEWER to SCENARIO_ROLE_VIEWER_PERMISSIONS,
               ROLE_EDITOR to SCENARIO_ROLE_EDITOR_PERMISSIONS,
               ROLE_VALIDATOR to SCENARIO_ROLE_VALIDATOR_PERMISSIONS,

--- a/src/main/kotlin/com/cosmotech/api/rbac/model/RbacAccessControl.kt
+++ b/src/main/kotlin/com/cosmotech/api/rbac/model/RbacAccessControl.kt
@@ -2,6 +2,6 @@
 // Licensed under the MIT license.
 package com.cosmotech.api.rbac.model
 
-import com.cosmotech.api.rbac.ROLE_NONE
+import com.cosmotech.api.rbac.ROLE_VIEWER
 
-open class RbacAccessControl(open var id: String = "emptyId", open var role: String = ROLE_NONE)
+open class RbacAccessControl(open var id: String = "emptyId", open var role: String = ROLE_VIEWER)

--- a/src/main/kotlin/com/cosmotech/api/rbac/model/RbacAccessControl.kt
+++ b/src/main/kotlin/com/cosmotech/api/rbac/model/RbacAccessControl.kt
@@ -2,6 +2,4 @@
 // Licensed under the MIT license.
 package com.cosmotech.api.rbac.model
 
-import com.cosmotech.api.rbac.ROLE_VIEWER
-
-open class RbacAccessControl(open var id: String = "emptyId", open var role: String = ROLE_VIEWER)
+data class RbacAccessControl(var id: String, var role: String)

--- a/src/main/kotlin/com/cosmotech/api/rbac/model/RbacSecurity.kt
+++ b/src/main/kotlin/com/cosmotech/api/rbac/model/RbacSecurity.kt
@@ -4,8 +4,8 @@ package com.cosmotech.api.rbac.model
 
 import com.cosmotech.api.rbac.ROLE_NONE
 
-open class RbacSecurity(
-    open var id: String?,
-    open var default: String = ROLE_NONE,
-    open var accessControlList: kotlin.collections.MutableList<RbacAccessControl> = mutableListOf()
+data class RbacSecurity(
+    var id: String?,
+    var default: String = ROLE_NONE,
+    var accessControlList: kotlin.collections.MutableList<RbacAccessControl> = mutableListOf()
 )

--- a/src/test/kotlin/com/cosmotech/api/rbac/CsmRbacTests.kt
+++ b/src/test/kotlin/com/cosmotech/api/rbac/CsmRbacTests.kt
@@ -262,6 +262,13 @@ class CsmRbacTests {
   }
 
   @Test
+  fun `add a user with role none KO`() {
+    assertThrows<CsmClientException> {
+      rbac.setUserRole(rbacSecurity, USER_NEW_READER, ROLE_NONE, rolesDefinition)
+    }
+  }
+
+  @Test
   fun `should throw NotFoundException if user not in parent user list`() {
     assertThrows<CsmResourceNotFoundException> {
       rbac.addUserRole(rbacSecurity, rbacSecurity, USER_NOTIN, USER_READER_ROLE, rolesDefinition)

--- a/src/test/kotlin/com/cosmotech/api/rbac/CsmRbacTests.kt
+++ b/src/test/kotlin/com/cosmotech/api/rbac/CsmRbacTests.kt
@@ -501,7 +501,6 @@ class CsmRbacTests {
   fun `get default role definition permissions`() {
     val expected: MutableMap<String, List<String>> =
         mutableMapOf(
-            ROLE_NONE to COMMON_ROLE_NONE_PERMISSIONS,
             ROLE_VIEWER to COMMON_ROLE_READER_PERMISSIONS,
             ROLE_USER to COMMON_ROLE_USER_PERMISSIONS,
             ROLE_EDITOR to COMMON_ROLE_EDITOR_PERMISSIONS,
@@ -523,7 +522,6 @@ class CsmRbacTests {
     definition.permissions.put(customRole, customRolePermissions)
     val expected: MutableMap<String, List<String>> =
         mutableMapOf(
-            ROLE_NONE to COMMON_ROLE_NONE_PERMISSIONS,
             ROLE_VIEWER to COMMON_ROLE_READER_PERMISSIONS,
             ROLE_USER to COMMON_ROLE_USER_PERMISSIONS,
             ROLE_EDITOR to COMMON_ROLE_EDITOR_PERMISSIONS,

--- a/src/test/kotlin/com/cosmotech/api/rbac/CsmRbacTests.kt
+++ b/src/test/kotlin/com/cosmotech/api/rbac/CsmRbacTests.kt
@@ -262,7 +262,7 @@ class CsmRbacTests {
   }
 
   @Test
-  fun `add a user with role none KO`() {
+  fun `adding a user with role none throws exception`() {
     assertThrows<CsmClientException> {
       rbac.setUserRole(rbacSecurity, USER_NEW_READER, ROLE_NONE, rolesDefinition)
     }


### PR DESCRIPTION
ROLE_NONE is dropped from Role Definition so not possible to use it in AccessControl
As we need it in default param, we check it in setDefault method & verifyDefault