### PR TITLE
Coverage adding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
   id("org.springframework.boot") version "2.7.2" apply false
   id("io.gitlab.arturbosch.detekt") version "1.22.0"
   id("pl.allegro.tech.build.axion-release") version "1.14.3"
+  id("org.jetbrains.kotlinx.kover") version "0.6.1"
   `maven-publish`
   // Apply the java-library plugin for API and implementation separation.
   `java-library`
@@ -221,4 +222,13 @@ dependencies {
   testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 
   annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+}
+
+kover {
+  filters {
+    classes {
+      includes +=
+          listOf("com.cosmotech.api.id.*", "com.cosmotech.api.rbac.*", "com.cosmotech.utils.*")
+    }
+  }
 }

--- a/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
+++ b/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
@@ -492,7 +492,7 @@ data class CsmPlatformProperties(
 
     data class PageSizing(
         /** Max result for a single page */
-        val maxResult: Int = 50
+        val defaultPageSize: Int = 50
     )
   }
 

--- a/src/main/kotlin/com/cosmotech/api/utils/RedisUtils.kt
+++ b/src/main/kotlin/com/cosmotech/api/utils/RedisUtils.kt
@@ -1,0 +1,28 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+package com.cosmotech.api.utils
+
+import org.springframework.data.domain.PageRequest
+
+fun constructPageRequest(page: Int?, size: Int?, maxSize: Int): PageRequest? {
+  return when {
+    page != null && size != null -> PageRequest.of(page, size)
+    page != null && size == null -> PageRequest.of(page, maxSize)
+    page == null && size != null -> PageRequest.of(0, size)
+    else -> null
+  }
+}
+
+fun <T> findAllPaginated(
+    maxResult: Int,
+    findAllLambda: (pageRequest: PageRequest) -> MutableList<T>
+): MutableList<T> {
+  var pageRequest = PageRequest.ofSize(maxResult)
+  var list = mutableListOf<T>()
+  do {
+    var objectList = findAllLambda(pageRequest)
+    pageRequest = pageRequest.next()
+    list.addAll(objectList)
+  } while (objectList.isNotEmpty())
+  return list
+}

--- a/src/main/kotlin/com/cosmotech/api/utils/RedisUtils.kt
+++ b/src/main/kotlin/com/cosmotech/api/utils/RedisUtils.kt
@@ -4,10 +4,10 @@ package com.cosmotech.api.utils
 
 import org.springframework.data.domain.PageRequest
 
-fun constructPageRequest(page: Int?, size: Int?, maxSize: Int): PageRequest? {
+fun constructPageRequest(page: Int?, size: Int?, defaultPageSize: Int): PageRequest? {
   return when {
     page != null && size != null -> PageRequest.of(page, size)
-    page != null && size == null -> PageRequest.of(page, maxSize)
+    page != null && size == null -> PageRequest.of(page, defaultPageSize)
     page == null && size != null -> PageRequest.of(0, size)
     else -> null
   }

--- a/src/test/kotlin/com/cosmotech/api/utils/AnyExtensionsTests.kt
+++ b/src/test/kotlin/com/cosmotech/api/utils/AnyExtensionsTests.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.assertThrows
 
-class AnyExtTests {
+class AnyExtensionsTests {
 
   @Test
   fun `changed - change when comparing null to non-null`() {

--- a/src/test/kotlin/com/cosmotech/api/utils/RedisUtilsTests.kt
+++ b/src/test/kotlin/com/cosmotech/api/utils/RedisUtilsTests.kt
@@ -1,0 +1,46 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+package com.cosmotech.api.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.springframework.data.domain.PageRequest
+
+const val DEFAULT_MAX_PAGE_SIZE = 100
+
+class RedisUtilsTests {
+
+  @Test
+  fun `constructPageRequest - should check multiple cases for page and size`() {
+    listOf(
+            Pair(1, 10) to PageRequest.of(1, 10),
+            Pair(null, 10) to PageRequest.of(0, 10),
+            Pair(1, null) to PageRequest.of(1, DEFAULT_MAX_PAGE_SIZE),
+            Pair(null, null) to null)
+        .forEach { (input, expected) ->
+          val actual = constructPageRequest(input.first, input.second, DEFAULT_MAX_PAGE_SIZE)
+          assertEquals(expected, actual)
+        }
+  }
+
+  @Test
+  fun `findAllPaginated - should check empty List`() {
+    val maxResult = 100
+    val findAllLambda = { _: PageRequest -> mutableListOf<Any>() }
+    val actual = findAllPaginated(maxResult, findAllLambda)
+    assertEquals(0, actual.size)
+  }
+
+  @Test
+  fun `findAllPaginated - should check non-empty List`() {
+    var counter = 3
+    val findAllLambda = { _: PageRequest ->
+      if (counter-- == 0) mutableListOf() else mutableListOf(Any(), Any(), Any(), Any(), Any())
+    }
+    listOf(5, 10, 15, 20, 50).forEach { maxResult ->
+      counter = 3
+      val actual = findAllPaginated(maxResult, findAllLambda)
+      assertEquals(15, actual.size)
+    }
+  }
+}


### PR DESCRIPTION
Connectors findAll can be represented like this:
```
  override fun findAllConnectors(page: Int?, size: Int?): List<Connector> {
    val maxResult = csmPlatformProperties.twincache.connector.maxResult
    var pageRequest = constructPageRequest(page, size, maxResult)
    if (pageRequest != null) {
      return connectorRepository.findAll(pageRequest).toList()
    }
    return findAllPaginated(maxResult) { connectorRepository.findAll(it).toList() }
  }
```