### PR TITLE
Redis helper methods

### DIFF
--- a/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
+++ b/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
@@ -468,6 +468,11 @@ data class CsmPlatformProperties(
       /** Twin cache query timeout. Kill a query after specified timeout (in millis) default 5000 */
       val queryTimeout: Long = 5000,
 
+      /**
+       * Twin cache query bulk expiration. Bulk expiration for a query (in seconds) default 86400
+       */
+      val queryBulkExpiration: Long = 86400,
+
       /** Twin cache query page information for organization */
       val organization: PageSizing = PageSizing(),
 

--- a/src/main/kotlin/com/cosmotech/api/utils/RedisUtils.kt
+++ b/src/main/kotlin/com/cosmotech/api/utils/RedisUtils.kt
@@ -2,6 +2,9 @@
 // Licensed under the MIT license.
 package com.cosmotech.api.utils
 
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import org.springframework.data.domain.PageRequest
 
 fun constructPageRequest(page: Int?, size: Int?, defaultPageSize: Int): PageRequest? {
@@ -25,4 +28,23 @@ fun <T> findAllPaginated(
     list.addAll(objectList)
   } while (objectList.isNotEmpty())
   return list
+}
+
+/**
+ * Zip a list of ByteArray with their file names.
+ * @param nameFilePair a list of Pair<String, ByteArray> where the first element is the file name
+ * and the second element is the byte array to zip
+ */
+fun zipBytesWithFileNames(nameFilePair: List<Pair<String, ByteArray>>): ByteArray? {
+  if (nameFilePair.isEmpty()) return null
+  val byteArrayOutputStream = ByteArrayOutputStream()
+  val zipOutputStream = ZipOutputStream(byteArrayOutputStream)
+  for (file in nameFilePair) {
+    val entry = ZipEntry(file.first).apply { size = file.second.size.toLong() }
+    zipOutputStream.putNextEntry(entry)
+    zipOutputStream.write(file.second)
+  }
+  zipOutputStream.closeEntry()
+  zipOutputStream.close()
+  return byteArrayOutputStream.toByteArray()
 }

--- a/src/main/kotlin/com/cosmotech/api/utils/StringExtensions.kt
+++ b/src/main/kotlin/com/cosmotech/api/utils/StringExtensions.kt
@@ -2,6 +2,10 @@
 // Licensed under the MIT license.
 package com.cosmotech.api.utils
 
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import javax.xml.bind.annotation.adapters.HexBinaryAdapter
+
 private const val KUBERNETES_RESOURCE_NAME_MAX_LENGTH = 63
 
 /**
@@ -28,3 +32,9 @@ fun String.sanitizeForRedis() = this.replace("@", "\\@").replace(".", "\\.").rep
 fun String.toSecurityConstraintQuery() =
     "((-@security_default:{none})|(@security_accessControlList_id:{${this.sanitizeForRedis()}}" +
         " -@security_accessControlList_role:{none}))"
+
+fun String.shaHash(): String {
+  val messageDigest = MessageDigest.getInstance("SHA-256")
+  messageDigest.update(this.toByteArray(StandardCharsets.UTF_8))
+  return (HexBinaryAdapter()).marshal(messageDigest.digest())
+}

--- a/src/test/kotlin/com/cosmotech/api/utils/RedisUtilsTests.kt
+++ b/src/test/kotlin/com/cosmotech/api/utils/RedisUtilsTests.kt
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 package com.cosmotech.api.utils
 
+import java.io.ByteArrayInputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.springframework.data.domain.PageRequest
@@ -41,6 +42,23 @@ class RedisUtilsTests {
       counter = 3
       val actual = findAllPaginated(maxResult, findAllLambda)
       assertEquals(15, actual.size)
+    }
+  }
+
+  @Test
+  fun `zipBytesWithFileNames - should check empty List`() {
+    val actual = zipBytesWithFileNames(emptyList())
+    assertEquals(null, actual)
+  }
+
+  @Test
+  fun `zipBytesWithFileNames - should check non-empty List`() {
+    val actual = zipBytesWithFileNames(listOf(Pair("test", ByteArray(10))))
+    ByteArrayInputStream(actual).use {
+      val zipInputStream = java.util.zip.ZipInputStream(it)
+      val entry = zipInputStream.nextEntry
+      assertEquals("test", entry.name)
+      assertEquals(ByteArray(10).size, zipInputStream.readAllBytes().size)
     }
   }
 }

--- a/src/test/kotlin/com/cosmotech/api/utils/StringExtensionsTests.kt
+++ b/src/test/kotlin/com/cosmotech/api/utils/StringExtensionsTests.kt
@@ -24,4 +24,12 @@ class StringExtensionsTests {
     val actual = input.sanitizeForRedis()
     assertEquals(expected, actual)
   }
+
+  @Test
+  fun `shaHash should return a SHA-256 hash of the input string`() {
+    val input = "test"
+    val expected = "9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08"
+    val actual = input.shaHash()
+    assertEquals(expected, actual)
+  }
 }


### PR DESCRIPTION
- util method to add byte array as a zip entry. To use with Redis for stocking bulks
- sha encoding string to use as a key for Redis for security purposes.