### PR TITLE
Put back the option to start the api without access to kubernetes

### DIFF
--- a/src/main/kotlin/com/cosmotech/api/utils/KubernetesApiConfig.kt
+++ b/src/main/kotlin/com/cosmotech/api/utils/KubernetesApiConfig.kt
@@ -8,14 +8,17 @@ import io.kubernetes.client.util.ClientBuilder
 import io.kubernetes.client.util.KubeConfig
 import java.io.FileReader
 import java.io.IOException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 open class KubernetesApiConfig {
   @Bean
+  @ConditionalOnProperty(
+      name = ["csm.platform.kubernetesAccessEnabled"], havingValue = "true", matchIfMissing = true)
   open fun coreV1Api(csmPlatformProperties: CsmPlatformProperties): CoreV1Api {
-    val kubernetesContext = System.getProperty("localKubernetesContext")
+    val kubernetesContext = System.getProperty("useKubernetesContext")
     if (kubernetesContext != null) {
       // Locate kube config file
       val kubeConfigPath =


### PR DESCRIPTION
- The kubernetes api client setup can be disabled using the property 'csm.platform.kubernetesAccessEnabled=false' with a runtime error if trying to use it
- If enabled, the kubernetes context can be overriden with the JVM property 'useKubernetesContext=my-context' (renamed from localKubernetesContext)