### PR TITLE
Rework the Loki service

### DIFF
--- a/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
+++ b/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
@@ -229,12 +229,6 @@ data class CsmPlatformProperties(
   data class Loki(
       /** Base Loki url */
       val baseUrl: String = "http://loki.default.svc.cluster.local:3100",
-
-      /** Query path for Loki service */
-      val queryPath: String = "/loki/api/v1/query_range",
-
-      /** Query range for logs (default: retrieve logs from past day) */
-      val queryDaysAgo: Long = 1
   )
   data class Argo(
       /** Argo service base Uri */


### PR DESCRIPTION
This fixes various issues including:
 - manual paging instead of the default 100 results
 - nanosecond start/end timestamp as expected instead of milliseconds
 - return a chronological string list instead of the direct loki response
 - query the dynamic loki configuration to avoid hardcoding limits that may not be valid for the query limit and time length