### PR TITLE
REDIS TLS support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ scmVersion {
 
 project.version = scmVersion.version
 
+project.logger.warn("Project version: ${project.version}")
+
 val kotlinJvmTarget = 21
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(kotlinJvmTarget)) } }

--- a/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
+++ b/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
@@ -392,6 +392,9 @@ data class CsmPlatformProperties(
       /** Twin cache port */
       val port: String = "6379",
 
+      /** Twin cache tls enabled */
+      val tls: Boolean = false,
+
       /** Twin cache user */
       val username: String = "default",
 

--- a/src/main/kotlin/com/cosmotech/api/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/cosmotech/api/redis/RedisConfig.kt
@@ -18,6 +18,7 @@ open class RedisConfig {
 
   @Value("\${spring.data.redis.port}") private lateinit var twincachePort: String
 
+  // This property path is compatible with spring.data.redis used in redis om also
   @Value("\${spring.data.redis.ssl.enabled}") private var twincacheTLS: Boolean = false
 
   @Value("\${spring.data.redis.password}") private lateinit var twincachePassword: String

--- a/src/main/kotlin/com/cosmotech/api/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/cosmotech/api/redis/RedisConfig.kt
@@ -18,7 +18,7 @@ open class RedisConfig {
 
   @Value("\${spring.data.redis.port}") private lateinit var twincachePort: String
 
-  // This property path is compatible with spring.data.redis used in redis om also
+  // This property path is compatible with spring.data.redis used by redis-om auto configuration
   @Value("\${spring.data.redis.ssl.enabled}") private var twincacheTLS: Boolean = false
 
   @Value("\${spring.data.redis.password}") private lateinit var twincachePassword: String

--- a/src/main/kotlin/com/cosmotech/api/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/cosmotech/api/redis/RedisConfig.kt
@@ -18,11 +18,14 @@ open class RedisConfig {
 
   @Value("\${spring.data.redis.port}") private lateinit var twincachePort: String
 
+  @Value("\${spring.data.redis.ssl.enabled}") private var twincacheTLS: Boolean = false
+
   @Value("\${spring.data.redis.password}") private lateinit var twincachePassword: String
 
   @Bean
   open fun csmJedisClientConfig(): JedisClientConfig =
       DefaultJedisClientConfig.builder()
+          .ssl(twincacheTLS)
           .password(twincachePassword)
           .timeoutMillis(Protocol.DEFAULT_TIMEOUT)
           .build()


### PR DESCRIPTION
TLS support for redis clients with csm.platform.twincache.tls property