### PR TITLE
Vcar/redis tls test bundle

### DIFF
--- a/src/main/kotlin/com/cosmotech/api/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/cosmotech/api/redis/RedisConfig.kt
@@ -22,27 +22,28 @@ open class RedisConfig {
   // This property path is compatible with spring.data.redis used by redis-om auto configuration
   @Value("\${spring.data.redis.ssl.enabled}") private var twincacheTLS: Boolean = false
 
-  @Value("\${spring.data.redis.ssl.bundle}") private var twinCacheTLSBundle: String? = null
+  @Value("\${spring.data.redis.ssl.bundle}") private var twinCacheTLSBundle: String = ""
 
   @Value("\${spring.data.redis.password}") private lateinit var twincachePassword: String
 
   @Bean
-  open fun csmJedisClientConfig(sslBundles: SslBundles): JedisClientConfig =
-      twinCacheTLSBundle?.let {
-        return DefaultJedisClientConfig.builder()
-            .ssl(twincacheTLS)
-            .sslSocketFactory(sslBundles.getBundle(it).createSslContext().socketFactory)
-            .password(twincachePassword)
-            .timeoutMillis(Protocol.DEFAULT_TIMEOUT)
-            .build()
-      }
-          ?: run {
-            return DefaultJedisClientConfig.builder()
-                .ssl(twincacheTLS)
-                .password(twincachePassword)
-                .timeoutMillis(Protocol.DEFAULT_TIMEOUT)
-                .build()
-          }
+  open fun csmJedisClientConfig(sslBundles: SslBundles): JedisClientConfig {
+    return if (twincacheTLS && twinCacheTLSBundle.isNotBlank()) {
+      DefaultJedisClientConfig.builder()
+          .ssl(twincacheTLS)
+          .sslSocketFactory(
+              sslBundles.getBundle(twinCacheTLSBundle).createSslContext().socketFactory)
+          .password(twincachePassword)
+          .timeoutMillis(Protocol.DEFAULT_TIMEOUT)
+          .build()
+    } else {
+      DefaultJedisClientConfig.builder()
+          .ssl(twincacheTLS)
+          .password(twincachePassword)
+          .timeoutMillis(Protocol.DEFAULT_TIMEOUT)
+          .build()
+    }
+  }
 
   @Bean
   open fun unifiedJedis(csmJedisClientConfig: JedisClientConfig): UnifiedJedis {

--- a/src/main/kotlin/com/cosmotech/api/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/cosmotech/api/redis/RedisConfig.kt
@@ -19,10 +19,12 @@ open class RedisConfig {
 
   @Value("\${spring.data.redis.port}") private lateinit var twincachePort: String
 
-  // This property path is compatible with spring.data.redis used by redis-om auto configuration
-  @Value("\${spring.data.redis.ssl.enabled}") private var twincacheTLS: Boolean = false
+  // This property path is not compatible with spring.data.redis used by redis-om auto configuration
+  @Value("\${csm.platform.twincache.tls.enabled}") private var twincacheTLS: Boolean = false
 
-  @Value("\${spring.data.redis.ssl.bundle}") private var twinCacheTLSBundle: String = ""
+  // This property path is not compatible with spring.data.redis used by redis-om auto configuration
+  // It is duplicated since spring.data.redis.ssl.bundle cannot be empty
+  @Value("\${csm.platform.twincache.tls.bundle}") private var twinCacheTLSBundle: String = ""
 
   @Value("\${spring.data.redis.password}") private lateinit var twincachePassword: String
 


### PR DESCRIPTION
test if nudle empty with ssl enabled AND change redis tls conf path to csm.platform because spring.data.redis does not handle correctly empty bundle name