### PR TITLE
revert: lettuce version update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -176,12 +176,6 @@ val testcontainersRedis = "1.6.4"
 
 dependencies {
   implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)) {
-    constraints {
-      implementation("io.lettuce:lettuce-core:6.5.1.RELEASE") {
-        because("spring boot 3.4.1 depends on  lettuce-core 6.4.1.RELEASE which has vulnerability" +
-                " https://github.com/advisories/GHSA-q4h9-7rxj-7gx which was fixed in 6.5.1.RELEASE")
-      }
-    }
   } 
 
 


### PR DESCRIPTION
In lettuce 6.5.1 the following error was
introduced: https://github.com/redis/lettuce/issues/3054 this is fixed in 6.5.2, but there are other problems and our integration tests continue failing. So we have to
revert back to lettuce 6.4.1 and still have GHSA-q4h9-7rxj-7gx2