### PR TITLE
Override handleMethodArgumentNotValid

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -175,9 +175,8 @@ val awaitilityKVersion = "4.2.2"
 val testcontainersRedis = "1.6.4"
 
 dependencies {
-  implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)) {
-  } 
-
+  implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+  implementation("net.minidev:json-smart:2.4.10")
 
   detekt("io.gitlab.arturbosch.detekt:detekt-cli:$detektVersion")
   detekt("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")


### PR DESCRIPTION
By doing this, the Cosmotech API will return clear error messages when you call endpoints with not valid arguments (in addition with field's constraints on OpenAPI side)