### PR TITLE
Remove some property fields

### DIFF
--- a/src/main/kotlin/com/cosmotech/api/config/CsmOpenAPIConfiguration.kt
+++ b/src/main/kotlin/com/cosmotech/api/config/CsmOpenAPIConfiguration.kt
@@ -38,13 +38,6 @@ open class CsmOpenAPIConfiguration(val csmPlatformProperties: CsmPlatformPropert
 
     openAPI.info.version = apiVersion
 
-    if (!csmPlatformProperties.vcsRef.isNullOrBlank()) {
-      openAPI.info.description += " / ${csmPlatformProperties.vcsRef}"
-    }
-    if (!csmPlatformProperties.commitId.isNullOrBlank()) {
-      openAPI.info.description += " / ${csmPlatformProperties.commitId}"
-    }
-
     // Remove any set of servers already defined in the input openapi.yaml,
     // so as to have the base URL auto-generated based on the incoming requests
     openAPI.servers = listOf()

--- a/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
+++ b/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
@@ -9,22 +9,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 /** Configuration Properties for the Cosmo Tech Platform */
 @ConfigurationProperties(prefix = "csm.platform")
 data class CsmPlatformProperties(
-
-    /** Platform summary */
-    val summary: String?,
-
-    /** Platform description */
-    val description: String?,
-
-    /** Platform version (MAJOR.MINOR.PATCH) */
-    val version: String?,
-
-    /** Platform exact commit ID */
-    val commitId: String? = null,
-
-    /** Platform exact Version-Control System reference */
-    val vcsRef: String? = null,
-
     /** API Configuration */
     val api: Api,
 


### PR DESCRIPTION
- csm.platform.{summary,description,version} are not used
- csm.platform.{commitId,vcsRef} should not be configurable at runtime, we'll inject them at build time from the build system