### PR TITLE
Upgrades

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '23'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -88,7 +88,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '23'
 
       - name: Setup Gradle
         if: ${{ endsWith(steps.previoustag.outputs.tag, '-SNAPSHOT') }}

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '23'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '23'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '23'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
- kotlin upgrade to 2.0.21
- github actions java-version set to 23
- Spring boot 3.4.1 to 3.4.4
- kover version 0.76 to 0.9.1
- java compatibility set to 21
- spring oauth from 6.4.2 to 6.4.4
- redis om spring from 0.9.1 to 0.9.10
- detekt from 1.23.7 to 1.23.8
- junit from 5.10.0 to 5.12.1
- remove ai.djl:api constraints on redis-om-spring dependency